### PR TITLE
fix/aws-vpc-peer: wrong cond on creation

### DIFF
--- a/tasks/aws-peer.yml
+++ b/tasks/aws-peer.yml
@@ -37,10 +37,10 @@
       ret_vpc_peer: "{{ item }}"
     when: (ret_vpc_peer.result is defined) and item.status.code != "deleted"
     with_items: "{{ ret_vpc_peer.result }}"
-  when: "ansible_version.full | version_compare('2.4', '<')"
 
 - debug: var=ret_vpc_peer
 
 - name: AWS | PEER save facts
   set_fact:
     vpc_peers: "{{ vpc_peers + [{'name':item_peer.tags.Name,'id':ret_vpc_peer.vpc_peering_connection_id}] }}"
+  when: ret_vpc_peer.vpc_peering_connection_id is defined


### PR DESCRIPTION
Fix conditionals when retrieving peering IDs